### PR TITLE
Fix reading the body of a response into the buffer

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -97,7 +97,7 @@ impl Packet {
         // body
         let body_length = length - 10;
         let mut body_buffer = Vec::with_capacity(body_length as usize);
-        try!(r.read_exact(&mut body_buffer));
+        try!(r.take(body_length as u64).read_to_end(&mut body_buffer));
         let body = String::from_utf8(body_buffer).ok().unwrap();
         // terminating nulls
         try!(r.read_u8());


### PR DESCRIPTION
Previously `read_exact(b)` was used, which reads exactly `b.len()` bytes into b (by repeatedly [slicing the buffer until is is empty](https://doc.rust-lang.org/stable/src/std/up/src/libstd/io/mod.rs.html#619-634)).

Unfortunately `Vec::with_capacity(l)` has length `0` and not `l`, which resulted in zero bytes being read every time.