### PR TITLE
Add support for multi-packet responses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,13 +22,17 @@ mod error;
 
 pub struct Connection {
     stream: BufStream<TcpStream>,
+    next_packet_id: i32,
 }
+
+const INITIAL_PACKET_ID: i32 = 1;
 
 impl Connection {
     pub fn connect<T: ToSocketAddrs>(address: T, password: &str) -> RconResult<Connection> {
         let tcp_stream = try!(TcpStream::connect(address));
         let mut conn = Connection {
             stream: BufStream::new(tcp_stream),
+            next_packet_id: INITIAL_PACKET_ID,
         };
 
         try!(conn.auth(password));
@@ -37,14 +41,31 @@ impl Connection {
     }
 
     pub fn cmd(&mut self, cmd: &str) -> io::Result<String> {
-        let send_result = self.send(PacketType::ExecCommand, cmd);
-        let received_packet = try!(send_result);
-        Ok(received_packet.get_body().to_string())
+        try!(self.send(PacketType::ExecCommand, cmd));
+
+        // the server processes packets in order, so send an empty packet and
+        // remember its id to detect the end of a multi-packet response
+        let end_id = try!(self.send(PacketType::ExecCommand, ""));
+
+        let mut result = String::new();
+
+        loop {
+            let received_packet = try!(self.recv());
+
+            if received_packet.get_id() == end_id {
+                // This is the response to the end-marker packet
+                break;
+            }
+
+            result += received_packet.get_body();
+        }
+
+        Ok(result)
     }
 
     fn auth(&mut self, password: &str) -> RconResult<()> {
-        let send_result = self.send(PacketType::Auth, password);
-        let received_packet = try!(send_result);
+        try!(self.send(PacketType::Auth, password));
+        let received_packet = try!(self.recv());
 
         if received_packet.is_error() {
             Err(RconError::Auth)
@@ -53,19 +74,27 @@ impl Connection {
         }
     }
 
-    // TODO: implement packet splitting
-    fn send(&mut self, ptype: PacketType, body: &str) -> io::Result<Packet> {
-        let id = 0x504F4F50; // man ascii ;P
-        let packet = Packet::new(id, ptype, body.to_string());
+    fn send(&mut self, ptype: PacketType, body: &str) -> io::Result<i32> {
+        let id = self.generate_packet_id();
 
-        //println!("Sending:\n{}", packet)
-
+        let packet = Packet::new(id, ptype, body.into());
         try!(packet.serialize(&mut self.stream));
 
-        let received_packet = try!(Packet::deserialize(&mut self.stream));
+        Ok(id)
+    }
 
-        //println!("Received:\n{}", received_packet)
+    fn recv(&mut self) -> io::Result<Packet> {
+        Packet::deserialize(&mut self.stream)
+    }
 
-        Ok(received_packet)
+    fn generate_packet_id(&mut self) -> i32 {
+        let id = self.next_packet_id;
+
+        // only use positive ids as the server uses negative ids to signal
+        // a failed authentication request
+        self.next_packet_id =
+            self.next_packet_id.checked_add(1).unwrap_or(INITIAL_PACKET_ID);
+
+        id
     }
 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -121,6 +121,10 @@ impl Packet {
     pub fn get_type(&self) -> PacketType {
         PacketType::from_i32(self.ptype, self.is_response)
     }
+
+    pub fn get_id(&self) -> i32 {
+        self.id
+    }
 }
 
 impl fmt::Debug for Packet {


### PR DESCRIPTION
See the commit message for implementation details.

This adds a new dependency on rand for generating the packet ids. If you don't like this, we could also use a counter or something similar.

The `checked_abs` method is only available in rust 1.13, which will hit stable in one week, so this currently only compiles with beta.