### PR TITLE
Improve error handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -17,26 +17,36 @@ pub type RconResult<T> = Result<T, RconError>;
 #[derive(Debug)]
 pub enum RconError {
     Auth,
-    Other(Box<Error>)
+    Io(io::Error)
 }
 
 impl Error for RconError {
     fn description(&self) -> &str {
         match *self {
             RconError::Auth => "authentication failed",
-            RconError::Other(ref err) => err.description()
+            RconError::Io(ref err) => err.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            RconError::Io(ref err) => Some(err),
+            _ => None,
         }
     }
 }
 
 impl fmt::Display for RconError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        match *self {
+            RconError::Io(ref err) => write!(fmt, "IO error: {}", err),
+            _ => write!(fmt, "{}", self.description()),
+        }
     }
 }
 
 impl From<io::Error> for RconError {
     fn from(err: io::Error) -> RconError {
-        RconError::Other(Box::new(err))
+        RconError::Io(err)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,7 @@ pub type Result<T> = result::Result<T, Error>;
 #[derive(Debug)]
 pub enum Error {
     Auth,
+    CommandTooLong,
     Io(io::Error)
 }
 
@@ -24,6 +25,7 @@ impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
             Error::Auth => "authentication failed",
+            Error::CommandTooLong => "command exceeds the maximum length",
             Error::Io(ref err) => err.description(),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,45 +8,45 @@
 // according to those terms.
 
 use std::io;
-use std::error::Error;
+use std::error::Error as StdError;
 use std::fmt;
-use std::convert::From;
+use std::result;
 
-pub type RconResult<T> = Result<T, RconError>;
+pub type Result<T> = result::Result<T, Error>;
 
 #[derive(Debug)]
-pub enum RconError {
+pub enum Error {
     Auth,
     Io(io::Error)
 }
 
-impl Error for RconError {
+impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
-            RconError::Auth => "authentication failed",
-            RconError::Io(ref err) => err.description(),
+            Error::Auth => "authentication failed",
+            Error::Io(ref err) => err.description(),
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&StdError> {
         match *self {
-            RconError::Io(ref err) => Some(err),
+            Error::Io(ref err) => Some(err),
             _ => None,
         }
     }
 }
 
-impl fmt::Display for RconError {
+impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            RconError::Io(ref err) => write!(fmt, "IO error: {}", err),
+            Error::Io(ref err) => write!(fmt, "IO error: {}", err),
             _ => write!(fmt, "{}", self.description()),
         }
     }
 }
 
-impl From<io::Error> for RconError {
-    fn from(err: io::Error) -> RconError {
-        RconError::Io(err)
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Self {
+        Error::Io(err)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ impl Connection {
         Ok(conn)
     }
 
-    pub fn cmd(&mut self, cmd: &str) -> io::Result<String> {
+    pub fn cmd(&mut self, cmd: &str) -> Result<String> {
         try!(self.send(PacketType::ExecCommand, cmd));
 
         // the server processes packets in order, so send an empty packet and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,9 @@ use std::net::{TcpStream, ToSocketAddrs};
 use std::io;
 use packet::{Packet, PacketType};
 use bufstream::BufStream;
-pub use error::RconResult;
-pub use error::RconError;
+
+pub use error::Result;
+pub use error::Error;
 
 mod packet;
 mod error;
@@ -28,7 +29,7 @@ pub struct Connection {
 const INITIAL_PACKET_ID: i32 = 1;
 
 impl Connection {
-    pub fn connect<T: ToSocketAddrs>(address: T, password: &str) -> RconResult<Connection> {
+    pub fn connect<T: ToSocketAddrs>(address: T, password: &str) -> Result<Connection> {
         let tcp_stream = try!(TcpStream::connect(address));
         let mut conn = Connection {
             stream: BufStream::new(tcp_stream),
@@ -63,12 +64,12 @@ impl Connection {
         Ok(result)
     }
 
-    fn auth(&mut self, password: &str) -> RconResult<()> {
+    fn auth(&mut self, password: &str) -> Result<()> {
         try!(self.send(PacketType::Auth, password));
         let received_packet = try!(self.recv());
 
         if received_packet.is_error() {
-            Err(RconError::Auth)
+            Err(Error::Auth)
         } else {
             Ok(())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,13 @@ impl Connection {
     }
 
     pub fn cmd(&mut self, cmd: &str) -> Result<String> {
+        // Minecraft only supports a request payload length of max 1446 byte.
+        // However some tests showed that only requests with a payload length
+        // of 1413 byte or lower work reliable.
+        if cmd.len() > 1413 {
+            return Err(Error::CommandTooLong);
+        }
+
         try!(self.send(PacketType::ExecCommand, cmd));
 
         // the server processes packets in order, so send an empty packet and


### PR DESCRIPTION
The first tree commits improve the error handling in general and fix #6 and #7.

The last commit introduces the new `CommandTooLong` error variant that is used to reject commands that exceed 1413 byte (see #5).

All commits are breaking API changes, so we should probably bump the version to at least `0.1.0`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/rust-rcon/10)
<!-- Reviewable:end -->
