### PR TITLE
Update tokio and other deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.0] - 2020-12-26
+
+### Breaking
+- upgraded to tokio 1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ repository = "https://github.com/panicbit/rust-rcon"
 edition = "2018"
 
 [dependencies]
-err-derive = "0.2.4"
-tokio = { version = "0.2.22", features = ["tcp", "io-util", "dns", "time"] }
+err-derive = "0.3.0"
+tokio = { version = "1.0.0", features = ["net", "io-util", "time", "macros"] }
 
 [dev-dependencies]
-tokio = { version = "0.2.22", features = ["macros"] }
+tokio = { version = "1.0.0", features = ["rt-multi-thread", "macros"] }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rcon"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["panicbit <panicbit@users.noreply.github.com>"]
 description = "An rcon protocol implementation"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ use packet::{Packet, PacketType};
 use std::io;
 use std::time::Duration;
 use tokio::net::{TcpStream, ToSocketAddrs};
-use tokio::time::delay_for;
 
 mod packet;
 
@@ -63,7 +62,7 @@ impl Connection {
         self.send(PacketType::ExecCommand, cmd).await?;
 
         if self.minecraft_quirks_enabled {
-            delay_for(Duration::from_millis(DELAY_TIME_MILLIS)).await;
+            tokio::time::sleep(Duration::from_millis(DELAY_TIME_MILLIS)).await;
         }
 
         let response = self.receive_response().await?;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -8,7 +8,7 @@
 // according to those terms.
 
 use std::io;
-use tokio::prelude::*;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PacketType {


### PR DESCRIPTION
This pull updates Tokio and makes required code changes. I need this change because i am upgrading my binary crate to Tokio 1.0 and my dependencies. Merry Christmas!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/rust-rcon/15)
<!-- Reviewable:end -->
