### PR TITLE
Add support for async_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,8 @@ edition = "2018"
 
 [dependencies]
 err-derive = "0.3.0"
-tokio = { version = "1.0.0", features = ["net", "io-util", "time", "macros"], optional = true }
-async-std = { version = "1.9.0", optional = true }
+async-std = { version = "1.9.0", default-features = false, features = ["async-io"] }
 bytes = "1.0.1"
 
 [dev-dependencies]
-tokio = { version = "1.0.0", features = ["rt-multi-thread", "macros"] }
-
-[features]
-default = ["runtime-tokio"]
-runtime-tokio = ["tokio"]
-runtime-async_std = ["async-std"]
+async-std = { version = "1.9.0", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,14 @@ edition = "2018"
 
 [dependencies]
 err-derive = "0.3.0"
-tokio = { version = "1.0.0", features = ["net", "io-util", "time", "macros"] }
+tokio = { version = "1.0.0", features = ["net", "io-util", "time", "macros"], optional = true }
+async-std = { version = "1.9.0", optional = true }
+bytes = "1.0.1"
 
 [dev-dependencies]
 tokio = { version = "1.0.0", features = ["rt-multi-thread", "macros"] }
 
 [features]
-default = []
+default = ["runtime-tokio"]
+runtime-tokio = ["tokio"]
+runtime-async_std = ["async-std"]

--- a/examples/factorio.rs
+++ b/examples/factorio.rs
@@ -1,6 +1,6 @@
 use rcon::{Connection, Error};
 
-#[tokio::main]
+#[async_std::main]
 async fn main() -> Result<(), Error> {
     let address = "localhost:1234";
     let mut conn = Connection::builder()

--- a/examples/minecraft.rs
+++ b/examples/minecraft.rs
@@ -14,7 +14,7 @@ use rcon::{Connection, Error};
     and the rcon password "test"
 */
 
-#[tokio::main]
+#[async_std::main]
 async fn main() -> Result<(), Error> {
     let address = "localhost:25575";
     let mut conn = Connection::builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,7 @@ use err_derive::Error;
 use packet::{Packet, PacketType};
 use std::io;
 use std::time::Duration;
-#[cfg(feature = "runtime-tokio")]
-use tokio::net::{TcpStream, ToSocketAddrs};
-#[cfg(feature = "runtime-tokio")]
-use tokio::time::sleep;
-#[cfg(feature = "runtime-async_std")]
 use async_std::net::{TcpStream, ToSocketAddrs};
-#[cfg(feature = "runtime-async_std")]
 use async_std::task::sleep;
 
 mod packet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,21 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+#[cfg(all(feature = "runtime-tokio", feature = "runtime-async_std"))]
+compile_error!("Only one runtime can be enabled at a time");
+
 use err_derive::Error;
 use packet::{Packet, PacketType};
 use std::io;
 use std::time::Duration;
+#[cfg(feature = "runtime-tokio")]
 use tokio::net::{TcpStream, ToSocketAddrs};
+#[cfg(feature = "runtime-tokio")]
+use tokio::time::sleep;
+#[cfg(feature = "runtime-async_std")]
+use async_std::net::{TcpStream, ToSocketAddrs};
+#[cfg(feature = "runtime-async_std")]
+use async_std::task::sleep;
 
 mod packet;
 
@@ -62,7 +72,7 @@ impl Connection {
         self.send(PacketType::ExecCommand, cmd).await?;
 
         if self.minecraft_quirks_enabled {
-            tokio::time::sleep(Duration::from_millis(DELAY_TIME_MILLIS)).await;
+            sleep(Duration::from_millis(DELAY_TIME_MILLIS)).await;
         }
 
         let response = self.receive_response().await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-#[cfg(all(feature = "runtime-tokio", feature = "runtime-async_std"))]
-compile_error!("Only one runtime can be enabled at a time");
-
 use err_derive::Error;
 use packet::{Packet, PacketType};
 use std::io;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -8,10 +8,7 @@
 // according to those terms.
 
 use std::io;
-#[cfg(feature = "runtime-tokio")]
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-#[cfg(feature = "runtime-async_std")]
-use async_std::io::{Read as AsyncRead, ReadExt, Write as AsyncWrite, prelude::WriteExt};
+use async_std::io::{Read, ReadExt, Write, prelude::WriteExt};
 use bytes::BufMut;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -67,7 +64,7 @@ impl Packet {
         self.id < 0
     }
 
-    pub async fn serialize<T: Unpin + AsyncWrite>(&self, w: &mut T) -> io::Result<()> {
+    pub async fn serialize<T: Unpin + Write>(&self, w: &mut T) -> io::Result<()> {
         // Write bytes to a buffer first so only one tcp packet is sent
         // This is done in order to not overwhelm a Minecraft server
         let mut buf = Vec::with_capacity(self.length as usize);
@@ -83,7 +80,7 @@ impl Packet {
         Ok(())
     }
 
-    pub async fn deserialize<T: Unpin + AsyncRead>(r: &mut T) -> io::Result<Packet> {
+    pub async fn deserialize<T: Unpin + Read>(r: &mut T) -> io::Result<Packet> {
         let mut buf  = [0u8; 4];
 
         r.read_exact(&mut buf).await?;


### PR DESCRIPTION
Remove tokio dependencies, and instead use async_std's async I/O.
Supports running on a tokio executor. It just works.
Change examples to use async_std's executor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/rust-rcon/17)
<!-- Reviewable:end -->
