### PR TITLE
Runtime agnosticism

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,32 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
+  build_tokio:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose --features rt-tokio
+  build_async_std:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose --all-targets --features rt-async-std
+  build_tokio_async_std:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose --all-targets --features rt-tokio,rt-async-std
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all-features --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,20 @@ resolver = "2"
 
 [dependencies]
 err-derive = "0.3.0"
-async-std = "1.9.0"
-bytes = "1.0.1"
+sync_wrapper = "0.1.1"
+tokio = { version = "1.10.1", features = ["io-util"] }
+
+async-std = { version = "1.9.0", optional = true }
+
+[features]
+default = []
+rt-async-std = ["async-std"]
+rt-tokio = ["tokio/net", "tokio/time"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "doc_cfg"]
 
 [dev-dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }
+futures-timer = "3.0.2"

--- a/examples/factorio.rs
+++ b/examples/factorio.rs
@@ -1,11 +1,12 @@
-use rcon::{Connection, Error};
+use rcon::{AsyncStdStream, Connection, Error};
 
 #[async_std::main]
 async fn main() -> Result<(), Error> {
     let address = "localhost:1234";
-    let mut conn = Connection::builder()
+    let mut conn = <Connection<AsyncStdStream>>::builder()
         .enable_factorio_quirks(true)
-        .connect(address, "test").await?;
+        .connect(address, "test")
+        .await?;
 
     demo(&mut conn, "/c print('hello')").await?;
     demo(&mut conn, "/c print('world')").await?;
@@ -14,7 +15,7 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-async fn demo(conn: &mut Connection, cmd: &str) -> Result<(), Error> {
+async fn demo(conn: &mut Connection<AsyncStdStream>, cmd: &str) -> Result<(), Error> {
     println!("request: {}", cmd);
     let resp = conn.cmd(cmd).await?;
     println!("response: {}", resp);

--- a/examples/minecraft.rs
+++ b/examples/minecraft.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use rcon::{Connection, Error};
+use rcon::{AsyncStdStream, Connection, Error};
 
 /*
     This example expects a Minecraft with rcon enabled on port 25575
@@ -17,9 +17,10 @@ use rcon::{Connection, Error};
 #[async_std::main]
 async fn main() -> Result<(), Error> {
     let address = "localhost:25575";
-    let mut conn = Connection::builder()
+    let mut conn = <Connection<AsyncStdStream>>::builder()
         .enable_minecraft_quirks(true)
-        .connect(address, "test").await?;
+        .connect(address, "test")
+        .await?;
 
     demo(&mut conn, "list").await?;
     demo(&mut conn, "say Rust lang rocks! ;P").await?;
@@ -28,7 +29,7 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-async fn demo(conn: &mut Connection, cmd: &str) -> Result<(), Error> {
+async fn demo(conn: &mut Connection<AsyncStdStream>, cmd: &str) -> Result<(), Error> {
     let resp = conn.cmd(cmd).await?;
     println!("{}", resp);
     Ok(())

--- a/examples/source-engine.rs
+++ b/examples/source-engine.rs
@@ -1,10 +1,11 @@
-use rcon::{Connection, Error};
+use rcon::{AsyncStdStream, Connection, Error};
 
 #[async_std::main]
 async fn main() -> Result<(), Error> {
     let address = "localhost:27015";
-    let mut conn = Connection::builder()
-        .connect(address, "test").await?;
+    let mut conn = <Connection<AsyncStdStream>>::builder()
+        .connect(address, "test")
+        .await?;
 
     demo(&mut conn, "status").await?;
     demo(&mut conn, "users").await?;
@@ -14,7 +15,7 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-async fn demo(conn: &mut Connection, cmd: &str) -> Result<(), Error> {
+async fn demo(conn: &mut Connection<AsyncStdStream>, cmd: &str) -> Result<(), Error> {
     println!("request: {}", cmd);
     let resp = conn.cmd(cmd).await?;
     println!("response: {}", resp);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,8 +274,9 @@ impl<T> Builder<T> {
     /// Using [futures-timer](https://docs.rs/futures-timer) instead of Tokio's native timer:
     ///
     /// ```
+    /// # use tokio::net::TcpStream;
     /// # async {
-    /// let connection = rcon::TokioConnection::builder()
+    /// let connection = <rcon::Connection<TcpStream>>::builder()
     ///     .enable_minecraft_quirks(true)
     ///     .sleep_fn(futures_timer::Delay::new)
     ///     .connect("localhost:25575", "hunter2")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,13 @@
 
 use err_derive::Error;
 use packet::{Packet, PacketType};
+use std::fmt::{self, Debug, Formatter};
 use std::future::Future;
 use std::io;
-use std::fmt::{self, Formatter, Debug};
 use std::marker::PhantomData;
 use std::pin::Pin;
-use std::time::Duration;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 #[cfg(feature = "rt-async-std")]
@@ -207,7 +207,8 @@ impl Debug for SleepFn {
     }
 }
 
-type CustomSleepFn = Arc<dyn Fn(Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
+type CustomSleepFn =
+    Arc<dyn Fn(Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
 
 impl SleepFn {
     async fn call(&mut self, duration: Duration) {
@@ -316,9 +317,7 @@ impl<T> Builder<T> {
         F: Fn(Duration) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = ()> + Send + 'static,
     {
-        self.sleep_fn = SleepFn::Custom(Arc::new(move |duration| {
-            Box::pin(f(duration))
-        }));
+        self.sleep_fn = SleepFn::Custom(Arc::new(move |duration| Box::pin(f(duration))));
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,13 +6,31 @@
 // at your option. All files in the project carrying such
 // notice may not be copied, modified, or distributed except
 // according to those terms.
+//! Asynchronous API for the RCON protocol used by games such as Minecraft and Factorio.
+//!
+//! # Feature flags
+//!
+//! - `rt-tokio`: Enable integration with the [Tokio](tokio) asynchronous runtime.
+//! - `rt-async-std`: Enable integration with the [async-std](async_std) asynchronous runtime.
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
 
 use err_derive::Error;
 use packet::{Packet, PacketType};
+use std::future::Future;
 use std::io;
+use std::marker::PhantomData;
+use std::pin::Pin;
 use std::time::Duration;
-use async_std::net::{TcpStream, ToSocketAddrs};
-use async_std::task::sleep;
+use sync_wrapper::SyncWrapper;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+#[cfg(feature = "rt-async-std")]
+mod rt_async_std;
+#[cfg(feature = "rt-async-std")]
+pub use rt_async_std::AsyncStdStream;
+
+#[cfg(feature = "rt-tokio")]
+mod rt_tokio;
 
 mod packet;
 
@@ -32,27 +50,40 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-pub struct Connection {
-    stream: TcpStream,
+pub struct Connection<T> {
+    io: T,
     next_packet_id: i32,
     minecraft_quirks_enabled: bool,
     factorio_quirks_enabled: bool,
+    sleep_fn: SleepFn,
 }
 
-impl Connection {
+impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
     /// Create a connectiion builder.
     /// Allows configuring the rcon connection.
-    pub fn builder() -> Builder {
+    pub fn builder() -> Builder<T> {
         Builder::new()
     }
 
-    /// Connect to an rcon server.
-    /// By default this enables minecraft quirks.
-    /// If you need to customize this behaviour, use a Builder.
-    pub async fn connect<T: ToSocketAddrs>(address: T, password: &str) -> Result<Connection> {
+    /// Perform a handshake on an existing connection to an rcon server.
+    ///
+    /// This is a lower-level method mostly useful when integrating this crate with another
+    /// runtime, or running rcon over a transport other than TCP. You generally will want to use
+    /// one of the higher-level `connect` methods.
+    ///
+    /// By default this enables Minecraft quirks.
+    /// If you need to customize this behaviour, use a [`Builder`].
+    ///
+    /// This method requires one of the runtime features to be activated so that Minecraft quirks
+    /// mode is able to asynchronously sleep. If you want to provide a custom sleep function, see
+    /// [`Builder::sleep_fn`].
+    #[cfg(any(feature = "rt-tokio", feature = "rt-async-std"))]
+    #[cfg_attr(doc_cfg, doc(cfg(any(feature = "rt-tokio", feature = "rt-async-std"))))]
+    pub async fn handshake(io: T, password: &str) -> Result<Self> {
         Self::builder()
             .enable_minecraft_quirks(true)
-            .connect(address, password).await
+            .handshake(io, password)
+            .await
     }
 
     pub async fn cmd(&mut self, cmd: &str) -> Result<String> {
@@ -63,7 +94,9 @@ impl Connection {
         self.send(PacketType::ExecCommand, cmd).await?;
 
         if self.minecraft_quirks_enabled {
-            sleep(Duration::from_millis(DELAY_TIME_MILLIS)).await;
+            self.sleep_fn
+                .call(Duration::from_millis(DELAY_TIME_MILLIS))
+                .await;
         }
 
         let response = self.receive_response().await?;
@@ -125,13 +158,13 @@ impl Connection {
 
         let packet = Packet::new(id, ptype, body.into());
 
-        packet.serialize(&mut self.stream).await?;
+        packet.serialize(&mut self.io).await?;
 
         Ok(id)
     }
 
     async fn receive_packet(&mut self) -> io::Result<Packet> {
-        Packet::deserialize(&mut self.stream).await
+        Packet::deserialize(&mut self.io).await
     }
 
     fn generate_packet_id(&mut self) -> i32 {
@@ -148,13 +181,60 @@ impl Connection {
     }
 }
 
-#[derive(Default, Debug)]
-pub struct Builder {
-    minecraft_quirks_enabled: bool,
-    factorio_quirks_enabled: bool,
+#[derive(Debug)]
+enum SleepFn {
+    #[cfg(feature = "rt-tokio")]
+    Tokio,
+    #[cfg(feature = "rt-async-std")]
+    AsyncStd,
+    #[cfg(not(any(feature = "rt-tokio", feature = "rt-async-std")))]
+    None,
+    Custom(SyncWrapper<CustomSleepFn>),
 }
 
-impl Builder {
+type CustomSleepFn = Box<dyn FnMut(Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send>;
+
+impl SleepFn {
+    async fn call(&mut self, duration: Duration) {
+        match self {
+            #[cfg(feature = "rt-tokio")]
+            Self::Tokio => tokio::time::sleep(duration).await,
+            #[cfg(feature = "rt-async-std")]
+            Self::AsyncStd => async_std::task::sleep(duration).await,
+            #[cfg(not(any(feature = "rt-tokio", feature = "rt-async-std")))]
+            Self::None => unreachable!(),
+            Self::Custom(f) => f.get_mut()(duration).await,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Builder<T> {
+    minecraft_quirks_enabled: bool,
+    factorio_quirks_enabled: bool,
+    sleep_fn: SleepFn,
+    _io: PhantomData<fn() -> T>,
+}
+
+impl<T> Default for Builder<T> {
+    fn default() -> Self {
+        #[cfg(feature = "rt-tokio")]
+        let sleep_fn = SleepFn::Tokio;
+        #[cfg(all(feature = "rt-async-std", not(feature = "rt-tokio")))]
+        let sleep_fn = SleepFn::AsyncStd;
+        #[cfg(not(any(feature = "rt-async-std", feature = "rt-tokio")))]
+        let sleep_fn = SleepFn::None;
+
+        Self {
+            minecraft_quirks_enabled: false,
+            factorio_quirks_enabled: false,
+            sleep_fn,
+            _io: PhantomData,
+        }
+    }
+}
+
+impl<T> Builder<T> {
     pub fn new() -> Self {
         Self::default()
     }
@@ -162,7 +242,7 @@ impl Builder {
     /// This enables the following quirks for Minecraft:
     ///
     /// Commands are delayed by 3ms to reduce the chance of crashing the server.
-    /// See https://bugs.mojang.com/browse/MC-72390
+    /// See <https://bugs.mojang.com/browse/MC-72390>.
     ///
     /// The command length is limited to 1413 bytes.
     /// Tests have shown the server to not work reliably
@@ -182,16 +262,72 @@ impl Builder {
         self
     }
 
-    pub async fn connect<A>(self, address: A, password: &str) -> Result<Connection>
+    /// Set a custom function to use for sleeping between requests when [Minecraft quirks mode is
+    /// enabled](Self::enable_minecraft_quirks).
+    ///
+    /// When either of the `rt-tokio` or `rt-async-std` feature flags is enabled, this library will
+    /// default to using the runtime's native sleeping function. This can be used to override it,
+    /// or set the sleeping function to use when no runtime feature is active.
+    ///
+    /// # Example
+    ///
+    /// Using [futures-timer](https://docs.rs/futures-timer) instead of Tokio's native timer:
+    ///
+    /// ```
+    /// # async {
+    /// let connection = rcon::TokioConnection::builder()
+    ///     .enable_minecraft_quirks(true)
+    ///     .sleep_fn(futures_timer::Delay::new)
+    ///     .connect("localhost:25575", "hunter2")
+    ///     .await?;
+    /// # drop(connection);
+    /// # rcon::Result::Ok(())
+    /// # };
+    /// ```
+    pub fn sleep_fn<F, Fut>(mut self, mut f: F) -> Self
     where
-        A: ToSocketAddrs
+        F: FnMut(Duration) -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
     {
-        let stream = TcpStream::connect(address).await?;
+        self.sleep_fn = SleepFn::Custom(SyncWrapper::new(Box::new(move |duration| {
+            Box::pin(f(duration))
+        })));
+        self
+    }
+
+    /// Perform a handshake on an existing connection to an rcon server.
+    ///
+    /// This is a lower-level method mostly useful when integrating this crate with another
+    /// runtime, or running rcon over a transport other than TCP. You generally will want to use
+    /// one of the higher-level `connect` methods.
+    ///
+    /// # Panics
+    ///
+    /// If neither of the `rt-tokio` or `rt-async-std` feature flags are activated, no [custom sleep
+    /// function](Self::sleep_fn) has been set and [Minecraft quirks](Self::enable_minecraft_quirks)
+    /// have been enabled, this function will panic as Minecraft quirks need some way to
+    /// asynchronously sleep.
+    pub async fn handshake(self, io: T, password: &str) -> Result<Connection<T>>
+    where
+        T: AsyncRead + AsyncWrite + Unpin,
+    {
+        #[cfg(not(any(feature = "rt-tokio", feature = "rt-async-std")))]
+        if self.minecraft_quirks_enabled && matches!(self.sleep_fn, SleepFn::None) {
+            panic!(
+                "\
+                Minecraft quirks mode is enabled, but no runtime or custom sleep function has been \
+                set. Enable one of the `rt-tokio` or `rt-async-std` feature flags, or set a custom \
+                sleep function with `rcon::Builder::sleep_fn`.\
+            "
+            );
+        }
+
         let mut conn = Connection {
-            stream,
+            io,
             next_packet_id: INITIAL_PACKET_ID,
             minecraft_quirks_enabled: self.minecraft_quirks_enabled,
             factorio_quirks_enabled: self.factorio_quirks_enabled,
+            sleep_fn: self.sleep_fn,
         };
 
         conn.auth(password).await?;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -8,8 +8,7 @@
 // according to those terms.
 
 use std::io;
-use async_std::io::{Read, ReadExt, Write, prelude::WriteExt};
-use bytes::BufMut;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PacketType {
@@ -64,24 +63,24 @@ impl Packet {
         self.id < 0
     }
 
-    pub async fn serialize<T: Unpin + Write>(&self, w: &mut T) -> io::Result<()> {
+    pub async fn serialize<T: Unpin + AsyncWrite>(&self, w: &mut T) -> io::Result<()> {
         // Write bytes to a buffer first so only one tcp packet is sent
         // This is done in order to not overwhelm a Minecraft server
         let mut buf = Vec::with_capacity(self.length as usize);
 
-        buf.put_slice(&self.length.to_le_bytes());
-        buf.put_slice(&self.id.to_le_bytes());
-        buf.put_slice(&self.ptype.to_i32().to_le_bytes());
-        buf.put_slice(self.body.as_bytes());
-        buf.put_slice(&[0x00, 0x00]);
+        buf.extend_from_slice(&self.length.to_le_bytes());
+        buf.extend_from_slice(&self.id.to_le_bytes());
+        buf.extend_from_slice(&self.ptype.to_i32().to_le_bytes());
+        buf.extend_from_slice(self.body.as_bytes());
+        buf.extend_from_slice(&[0x00, 0x00]);
 
         w.write_all(&buf).await?;
 
         Ok(())
     }
 
-    pub async fn deserialize<T: Unpin + Read>(r: &mut T) -> io::Result<Packet> {
-        let mut buf  = [0u8; 4];
+    pub async fn deserialize<T: Unpin + AsyncRead>(r: &mut T) -> io::Result<Packet> {
+        let mut buf = [0u8; 4];
 
         r.read_exact(&mut buf).await?;
         let length = i32::from_le_bytes(buf);

--- a/src/rt_async_std.rs
+++ b/src/rt_async_std.rs
@@ -1,0 +1,86 @@
+use async_std::io::{Read, Write};
+use async_std::net::{TcpStream, ToSocketAddrs};
+use async_std::task::ready;
+use std::io::{self, IoSlice};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead as TokioRead, AsyncWrite as TokioWrite, ReadBuf};
+
+use crate::{Builder, Connection, Result};
+
+impl Connection<AsyncStdStream> {
+    /// Connect to an rcon server using the [async-std](async_std) runtime.
+    ///
+    /// By default this enables Minecraft quirks.
+    /// If you need to customize this behaviour, use a [`Builder`].
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rt-async-std")))]
+    pub async fn connect<A: ToSocketAddrs>(address: A, password: &str) -> Result<Self> {
+        Self::builder()
+            .enable_minecraft_quirks(true)
+            .connect(address, password)
+            .await
+    }
+}
+
+impl Builder<AsyncStdStream> {
+    /// Connect to an rcon server using the [async-std](async_std) runtime.
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rt-async-std")))]
+    #[cfg_attr(not(feature = "tokio"), allow(unused_mut))]
+    pub async fn connect<A: ToSocketAddrs>(
+        mut self,
+        address: A,
+        password: &str,
+    ) -> Result<Connection<AsyncStdStream>> {
+        // If the `rt-tokio` feature flag is also enabled the sleep_fn will use it by default, so
+        // we have to change it to use async-std instead.
+        #[cfg(feature = "rt-tokio")]
+        if let crate::SleepFn::Tokio = self.sleep_fn {
+            self.sleep_fn = crate::SleepFn::AsyncStd;
+        }
+        self.handshake(AsyncStdStream(TcpStream::connect(address).await?), password)
+            .await
+    }
+}
+
+/// The inner transport of an [async-std](async_std) rcon connection.
+///
+/// This is a simple wrapper around a [`TcpStream`] that implements Tokio's I/O traits so it can be
+/// used inside [`Connection`].
+#[derive(Debug)]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rt-async-std")))]
+pub struct AsyncStdStream(pub TcpStream);
+
+impl TokioRead for AsyncStdStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let bytes = ready!(Pin::new(&mut self.0).poll_read(cx, buf.initialize_unfilled()))?;
+        buf.advance(bytes);
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl TokioWrite for AsyncStdStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.0).poll_write(cx, buf)
+    }
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.0).poll_flush(cx)
+    }
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.0).poll_close(cx)
+    }
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.0).poll_write_vectored(cx, bufs)
+    }
+}

--- a/src/rt_tokio.rs
+++ b/src/rt_tokio.rs
@@ -1,0 +1,30 @@
+use tokio::net::{TcpStream, ToSocketAddrs};
+
+use crate::{Builder, Connection, Result};
+
+impl Connection<TcpStream> {
+    /// Connect to an rcon server using the [Tokio](tokio) runtime.
+    ///
+    /// By default this enables Minecraft quirks.
+    /// If you need to customize this behaviour, use a [`Builder`].
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rt-tokio")))]
+    pub async fn connect<A: ToSocketAddrs>(address: A, password: &str) -> Result<Self> {
+        Self::builder()
+            .enable_minecraft_quirks(true)
+            .connect(address, password)
+            .await
+    }
+}
+
+impl Builder<TcpStream> {
+    /// Connect to an rcon server using the [Tokio](tokio) runtime.
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rt-tokio")))]
+    pub async fn connect<A: ToSocketAddrs>(
+        self,
+        address: A,
+        password: &str,
+    ) -> Result<Connection<TcpStream>> {
+        self.handshake(TcpStream::connect(address).await?, password)
+            .await
+    }
+}


### PR DESCRIPTION
By storing the inner stream used by `Connection` as a generic instead of hard-coding it as an async-std `TcpStream`, the library can be made agnostic to the runtime being used. This also has the additional benefit of supporting rcon over transports other than TCP, if that's something users want to do.

There are `rt-tokio` and `rt-async-std` feature flags, which add the `connect` shortcut method that uses their respective runtime's implementation of TCP - but this is just a convenience, users are free to use this library on top of any TCP implementation they like. I took care to make sure that the feature flags are additive. The feature-gated items in the library are marked as such in the documentation by using `doc_cfg`, which is enabled automatically when building in docs.rs and can be enabled locally with `RUSTDOCFLAGS="--cfg doc_cfg"` and a nightly compiler.

I chose to have the `Connection` type use Tokio's I/O traits because they are more efficient (`ReadBuf` allows reading into uninitialized bytes), stable (Tokio is post-1.0) and widely used than the ones from `futures-io`. As a result, `Connection<async_std::net::TcpStream>` does not work directly, but that is easily worked around by having a wrapper type `AsyncStdStream` that implements Tokio's I/O traits.

Miscellaneous changes:
- I removed the unnecessary `bytes` dependency.
- I ran rustfmt, which did change some formatting in places.
- I added a `sync_wrapper` dependency to avoid an unnecessary `Sync` bound on `sleep_fn` without `unsafe`. It's a tiny crate, so I don't think it will impact compile times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/rust-rcon/22)
<!-- Reviewable:end -->
