### PR TITLE
implement Clone in Builder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ impl Connection {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct Builder {
     minecraft_quirks_enabled: bool,
     factorio_quirks_enabled: bool,


### PR DESCRIPTION
When I want to connect to a server, it's good to support cloning. It's also good to have address and username to Builder but it's out of scope I think

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/rust-rcon/23)
<!-- Reviewable:end -->
